### PR TITLE
hacks to fix installation of STAR-CCN+ 2410_008 which uses 19.06.008 as internal version

### DIFF
--- a/easybuild/easyblocks/s/star_ccm.py
+++ b/easybuild/easyblocks/s/star_ccm.py
@@ -126,9 +126,22 @@ class EB_STAR_minus_CCM_plus_(EasyBlock):
         # rely on sanity check to catch problems with the installation
         run_cmd(cmd, log_all=False, log_ok=False, simple=False)
 
+        if self.aol_install:
+            # we expect to find a subdirectory that is not called 'sip' and looks like a version number,
+            # that's what we want to copy...
+            contents = os.listdir(self.builddir)
+            for entry in contents:
+                if entry != 'sip' and os.path.isdir(entry) and entry[0] >= '0' and entry[0] <= '9':
+                    self.log.info("Found entry to move to installdir: %s" % entry)
+                    run_cmd("mv " + os.path.join(self.builddir, entry) + ' ' + self.installdir)
+                    break;
+                else:
+                    self.log.info("Skipping entry '%s' in build dir..." % entry)
+
     def find_starccm_subdirs(self):
         """Determine subdirectory of install directory in which STAR-CCM+ was installed."""
         starccm_subdir_pattern = os.path.join(self.version + '*', 'STAR-CCM+%s*' % self.version)
+        starccm_subdir_pattern = os.path.join('*', 'STAR-CCM+[0-9R._-]*')
 
         if self.dry_run:
             self.starccm_subdir = starccm_subdir_pattern
@@ -146,7 +159,9 @@ class EB_STAR_minus_CCM_plus_(EasyBlock):
                 else:
                     raise
 
-        self.starview_subdir = os.path.join(os.path.dirname(self.starccm_subdir), 'STAR-View+%s' % self.version)
+        topdir = os.path.dirname(self.starccm_subdir)
+        version_dir = os.path.basename(topdir)
+        self.starview_subdir = os.path.join(topdir, 'STAR-View+%s' % version_dir)
 
     def sanity_check_step(self):
         """Custom sanity check for STAR-CCM+."""


### PR DESCRIPTION
@WilleBell I hacked together these additional changes to get STAR-CCM+ version 2410_008 installed with EasyBuild, on top of what you have in https://github.com/easybuilders/easybuild-easyblocks/pull/3510

They're necessary because that version actually uses `19.06.008` as internal version, so there's no `2410_008` directory to be found.

Could probably use some polishing, but it does work.

This version of the easyblock does still require that you first extract the `.aol` file from the tarball, ideally the easyblock does that by itself...